### PR TITLE
Switch to LibZMQ3 (fix broken install on OS X).

### DIFF
--- a/lib/Exobrain/Bus.pm
+++ b/lib/Exobrain/Bus.pm
@@ -3,7 +3,7 @@ use v5.10.0;
 use strict;
 use warnings;
 
-use ZMQ::LibZMQ2;
+use ZMQ::LibZMQ3;
 use ZMQ::Constants qw(ZMQ_SUB ZMQ_PUB ZMQ_SUBSCRIBE ZMQ_RCVMORE);
 
 use Moose;

--- a/lib/Exobrain/Message.pm
+++ b/lib/Exobrain/Message.pm
@@ -8,7 +8,7 @@ use Moose::Role;
 use Moose::Util::TypeConstraints;
 use Carp;
 use ZMQ::Constants qw(ZMQ_SNDMORE);
-use ZMQ::LibZMQ2;
+use ZMQ::LibZMQ3;
 use JSON::Any;
 use Data::Dumper;
 
@@ -69,7 +69,7 @@ func payload($name, @args) {
             is       => 'ro',
             required => 1,
             @args
-        ) 
+        )
     );
 }
 
@@ -106,7 +106,7 @@ method data() {
     my $meta     = $self->meta;
     my @attrs    = $self->meta->get_attribute_list;
 
-    my @payloads = grep 
+    my @payloads = grep
         { $meta->get_attribute($_)->does( PAYLOAD_CLASS ) } @attrs
     ;
 

--- a/lib/Exobrain/Message/Raw.pm
+++ b/lib/Exobrain/Message/Raw.pm
@@ -2,7 +2,7 @@ package Exobrain::Message::Raw;
 use v5.10.0;
 use Moose;
 use ZMQ::Constants qw(ZMQ_SNDMORE);
-use ZMQ::LibZMQ2;
+use ZMQ::LibZMQ3;
 use JSON::Any;
 use Method::Signatures;
 use Carp;

--- a/lib/Exobrain/Router.pm
+++ b/lib/Exobrain/Router.pm
@@ -4,14 +4,14 @@ use Moose;
 use warnings;
 use Method::Signatures;
 use Carp qw(croak);
-use ZMQ::LibZMQ2;
+use ZMQ::LibZMQ3;
 use ZMQ::Constants qw(ZMQ_SUB ZMQ_SUBSCRIBE ZMQ_PUB ZMQ_FORWARDER);
 
 has subscriber => (is => 'ro', default => 'tcp://127.0.0.1:3546');     # Subscribers connect here
 has publisher  => (is => 'ro', default => 'tcp://127.0.0.1:3547');     # Publishers connect here
 has server     => (is => 'ro', isa => 'Bool', default => 0);
 
-# Clients should never call start. 
+# Clients should never call start.
 
 method start() {
 


### PR DESCRIPTION
LibZMQ3 won't build on OS X---or won't, at least, with the latest version of
libzmq, installed with homebrew (`brew install zmq`). Switching to LibZMQ3
fixes this, but it might break other things.

I was _trying_ to install exobrain to work on adding TravisCI integration (issue #21), but got stuck installing the dependencies (you weren't kidding about having a lot of them!). This doesn't break anything on my system, but it might on yours, depending on your libzmq version. Feel free to ignore if it does!
