### PR TITLE
Fix Travis-CI build: install 'develop' dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,7 @@ install:
     - cpanm --notest ExtUtils::MakeMaker
 
     - dzil authordeps | cpanm --notest --skip-satisfied
-    - dzil listdeps   | cpanm --notest --skip-satisfied
-
-    # Manually install Pod::Coverage::TrustPod for now.
-    # See rjbs/Dist-Zilla#283
-    
-    - cpanm --notest --skip-satisfied Pod::Coverage::TrustPod
+    - dzil listdeps --author | cpanm --notest --skip-satisfied
 
 script:
     - dzil test --all


### PR DESCRIPTION
Use `dzil listdeps --author` instead of `dzil listdeps` to install all dzil build dependencies.

Fixes rjbs/Dist-Zilla#283.
See rjbs/Dist-Zilla#210 for what changed recently in Dist::Zilla and the rationale.
