### PR TITLE
Fix issue reported in #58

### DIFF
--- a/bin/exobrain
+++ b/bin/exobrain
@@ -92,7 +92,7 @@ elsif ($command eq 'setup') {
     }
     else {
         say "Creating $exobrain_log";
-        make_path($exobrain_log);
+        make_path("$exobrain_log");
     }
 
     my $exe     = $0;

--- a/lib/Exobrain/Config.pm
+++ b/lib/Exobrain/Config.pm
@@ -96,7 +96,7 @@ sub write_config {
 
         # Make our config dir if it doesn't exist.
         if (not -e $config_dir) {
-            make_path($config_dir)
+            make_path("$config_dir");
         }
 
         $config_file = "$config_dir/$file";


### PR DESCRIPTION
~/.config/ may be a predominantly ubuntu or debian default. make_path will create it if it doesn't exist and File::Path is a core library.
