### PR TITLE
This is a brute force but simple method - fixes #53

### DIFF
--- a/lib/Exobrain/Bus.pm
+++ b/lib/Exobrain/Bus.pm
@@ -48,6 +48,16 @@ sub BUILD {
     elsif ($type eq 'PUB') {
         my $socket = $context->socket(ZMQ_PUB);
         $socket->connect($self->router->publisher);
+        
+        # Unfortunately ZMQ in some scenarios will try to send
+        # data to a socket that isn't ready. ZMQ_EVENTS looked
+        # interesting however seems to respond the same
+        # regardless of it being ready. This is quite brute force
+        # but solves it. We could make this configurable and
+        # possibly utilise Time::HiRes to tune it to be faster. 
+        # 2014-09-23 - Leon Wright < leon@cpan.org >
+        sleep 1;
+
         $self->_socket($socket);
     }
     else {


### PR DESCRIPTION
That appears to work consistently on ZMQ 4. Confusingly packaged as:

``` bash
leon@gandalf:~/git/exobrain$ dpkg -l|grep zmq
ii  libzmq3:amd64                         4.0.4+dfsg-2                  amd64        lightweight messaging kernel (shared library)
ii  libzmq3-dev:amd64                     4.0.4+dfsg-2                  amd64        lightweight messaging kernel (development files)
```

Added a bit of commentary as well. sleeps are my _least_ favourite way to fix these kinds of things.
