### PR TITLE
Add minimum versions.

### DIFF
--- a/bin/actions/rtm-adder
+++ b/bin/actions/rtm-adder
@@ -6,7 +6,7 @@ use autodie;
 use POSIX qw(strftime);
 
 use Exobrain;
-use WebService::RTMAgent;
+use WebService::RTMAgent 0.600;
 
 # PODNAME: rtm-adder
 # ABSTRACT: Add TODO items to RememberTheMilk from twitter

--- a/dist.ini
+++ b/dist.ini
@@ -28,13 +28,6 @@ critic_config = perlcritic.rc
 [PodWeaver]
 
 [Prereqs]
-; Some modules have bugs in older versions. Specific minimum
-; bug-free requirements.
-;
-; TODO: Specify these in the code instead.
-WebService::RTMAgent = 0.600
-Devel::Pragma = 0.60
-
 ; We want Ubic for process managment.
 Ubic = 0
 

--- a/lib/Exobrain/JSONify.pm
+++ b/lib/Exobrain/JSONify.pm
@@ -1,7 +1,7 @@
 package Exobrain::JSONify;
 use Moose::Role;
 use Storable qw(dclone);
-use Data::Structure::Util qw(unbless);
+use Data::Structure::Util 0.16 qw(unbless);
 
 # Basic role that allows converting self object into JSON.
 # Really we should use MooseX::Storage instead.


### PR DESCRIPTION
Devel::Pragma seems no longer needed (ack Devel::Pragma show no lines)
Data::Structure::Util 0.15 and earlier do not pass tests in 5.20, so
require latest version.
WebService::RTMAgent version added in bin/actions/rtm-adder