### PR TITLE
Fix typo in comment in main Exobrain module

### DIFF
--- a/lib/Exobrain.pm
+++ b/lib/Exobrain.pm
@@ -224,7 +224,7 @@ method watch_loop(
         priority => -1,
     );
 
-Takes a mandatory message, and any arguments that can be passeed to
+Takes a mandatory message, and any arguments that can be passed to
 L<Exobrain::Intent::Notify>, and notifies the user.  At the time of
 writing, notifications are done by the pushover end-point by default.
 


### PR DESCRIPTION
This is a PR related to the Perl Request Challenge 2016. I was taking a look at the source to find where I can make some code changes and just stumbled upon this typo. It's very minor, I realize but promise there is real code changing in the works too :smile: 

Here is the first PR I suppose to get things warmed up!