### PR TITLE
Make sure the phone number consists of only digits

### DIFF
--- a/lib/Exobrain/Types.pm
+++ b/lib/Exobrain/Types.pm
@@ -58,10 +58,11 @@ subtype SmsStr,
     where { length($_) <= 160 }
 ;
 
-# TODO: Properly define phone numbers
+# Phone number type. Consists of only digits
+#   Example: 18005555555 or 1234567
 subtype PhoneNum,
     as Str,
-    where { 1 },
+    where { $_ =~ /\d+/ },
 ;
 
 subtype PosNum,


### PR DESCRIPTION
I saw this TODO and thought this would be straight forward to tackle. I was thinking of also adding a lower and upper bound in length. Researching phone number lengths made it seem like there is an international standard of 15 - 16 digits. We could increase this to maybe 20 as a catch all. What are your thoughts?

Valid formats as of now are only digits so `1234567` or `18005551234` etc.

Also, I did not see anywhere to add/update tests to check this code change. Any pointers regarding that, feels dirty not to have a test for this change :smile: 
