### PR TITLE
Fix for bug in Exobrain::Config->write_config

### DIFF
--- a/lib/Exobrain/Config.pm
+++ b/lib/Exobrain/Config.pm
@@ -89,7 +89,7 @@ sub write_config {
     my $config_file;
 
     if ($ENV{EXOBRAIN_CONFIG}) {
-        $config_file = "ENV{EXOBRAIN_CONFIG}/$file";
+        $config_file = "$ENV{EXOBRAIN_CONFIG}/$file";
     }
     else {
         my $config_dir = File::XDG->new(name => 'exobrain')->config_home;

--- a/t/config.t
+++ b/t/config.t
@@ -14,4 +14,9 @@ my $config = Exobrain::Config->new;
 is($config->{Test}{foo},  "baz", "Override data test");
 is($config->{Test}{nyan}, "cat", "Simple config test");
 
+my $res = Exobrain::Config->write_config('write_test.ini', "Hello World!\n");
+like($res, qr/write_test\.ini$/, 'New config file created');
+is(-s $res, 13, 'New config file has correct size');
+ok(unlink $res, 'Cleanup');
+
 done_testing;


### PR DESCRIPTION
Here is a PR to fix a simple bug in Exobrain::Config->write_config. Thanks to a missing $ symbol the method would attempt to write to a non-existent path if $ENV{EXOBRAIN_CONFIG} had been set. This now seems to work as intended. Some tests have also been added to t/config.t to test this and improve the coverage.

This PR has been created as part of the [CPAN PR Challenge](http://cpan-prc.org/) - thanks for participating.
